### PR TITLE
Revert "CompatHelper: add new compat entry for "FastRounding" at version "0.3""

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,6 @@ ValidatedNumerics = "d621b6e3-7715-5857-9c6f-c67000ef6083"
 [compat]
 Arpack = ">= 0.3"
 DualNumbers = "0.6"
-FastRounding = "0.3"
 LaTeXStrings = "1.1"
 RecipesBase = "1.0"
 TaylorSeries = "0.10"


### PR DESCRIPTION
Reverts orkolorko/InvariantMeasures.jl#7, seems to break compatiblity with IntervalArithmetics.jl